### PR TITLE
Create AGENTS guide and add Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__
+.git
+*.pyc
+*.pyo
+*.pyd
+.gitbook_worker
+.gitignore
+.DS_Store
+*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Evaluation
+
+This project provides a Python package `gitbook-worker` for processing GitBook repositories. Key observations:
+
+- **License**: The repository is MIT licensed as seen in `LICENSE`.
+- **Packaging**: Uses `pyproject.toml` with Python >=3.10 and defines an entry point `gitbook-worker`.
+- **Tests**: Contains a comprehensive pytest suite (`gitbook_worker/tests`) with over 60 tests that currently pass.
+- **Documentation**: Includes Sphinx docs under `gitbook_worker/docs` and a detailed package README.
+- **Docker**: A Dockerfile for the Pandoc build environment exists under `gitbook_worker/src/gitbook_worker`.
+- **Root README**: Very brief; Docker usage instructions were missing prior to this sprint.
+
+Overall the project is well structured, but a top-level Docker workflow was not available which meant results could vary between host systems.
+
+# Sprint Plan
+
+1. **Dockerize worker** – Provide a Dockerfile at the repository root so the application can run in a consistent container regardless of the host OS.
+2. **Improve documentation** – Expand the root README with build and usage instructions.
+3. **CI integration** – Add GitHub Actions workflow running tests and building the Docker image.
+4. **Future enhancements** – Consider publishing the image to a registry and adding more usage examples in the docs.
+
+## Sprint 1 goal
+Create a root Dockerfile and `.dockerignore` so the gitbook worker can be executed through Docker, ensuring the same environment on every system.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+# install pandoc and basic TeX packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends pandoc texlive texlive-latex-extra texlive-fonts-extra lmodern fonts-dejavu wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# install OpenMoji fonts for emoji support
+RUN mkdir -p /usr/share/fonts && \
+    wget -O /usr/share/fonts/OpenMoji-black-glyf.ttf https://github.com/hfg-gmuend/openmoji/raw/master/font/OpenMoji-black-glyf/OpenMoji-black-glyf.ttf && \
+    wget -O /usr/share/fonts/OpenMoji-color-glyf_colr_0.ttf https://github.com/hfg-gmuend/openmoji/raw/master/font/OpenMoji-color-glyf_colr_0/OpenMoji-color-glyf_colr_0.ttf && \
+    fc-cache -f -v
+
+WORKDIR /app
+
+# copy project and install
+COPY gitbook_worker/ ./gitbook_worker
+RUN pip install --no-cache-dir ./gitbook_worker
+
+ENTRYPOINT ["gitbook-worker"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # gitbook_worker
-Yet another gitbook worker
+
+This repository contains a GitBook processing helper written in Python. It is licensed under the MIT license.
+
+## Usage with Docker
+
+Build the Docker image:
+
+```bash
+docker build -t gitbook-worker .
+```
+
+Run the worker inside the container:
+
+```bash
+docker run --rm -v $(pwd):/data gitbook-worker --help
+```
+
+Mount your work directories accordingly to process a repository.


### PR DESCRIPTION
## Summary
- add an AGENTS.md with repository evaluation and a sprint plan
- supply a Dockerfile and `.dockerignore` for a reproducible worker environment
- extend root README with Docker build and run instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68736c108d34832ab0611ee0bee0a6e9