### PR TITLE
Implement Sprint 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ This repository contains a GitBook processing helper written in Python. It is li
 
 ## Usage with Docker
 
-Build the Docker image:
+The repository includes a `Dockerfile` at the project root. It creates a
+minimal environment with Pandoc and TeXLive so the worker can run
+consistently on any host. The accompanying `.dockerignore` file excludes
+unnecessary sources from the build context.
+
+Build the container image:
 
 ```bash
 docker build -t gitbook-worker .
@@ -16,4 +21,13 @@ Run the worker inside the container:
 docker run --rm -v $(pwd):/data gitbook-worker --help
 ```
 
-Mount your work directories accordingly to process a repository.
+You can also install the package locally and use the helper script
+`gitbook-worker-docker`. It builds the image if needed and runs the worker in the
+container while mounting the current directory:
+
+```bash
+pip install -e gitbook_worker
+gitbook-worker-docker --help
+```
+
+Mount your working directories as needed to process a GitBook repository.

--- a/gitbook_worker/pyproject.toml
+++ b/gitbook_worker/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.scripts]
 gitbook-worker = "gitbook_worker.__main__:main"
+gitbook-worker-docker = "gitbook_worker.docker_cli:main"
 
 [tool.setuptools.package-data]
 "gitbook_worker" = ["landscape.lua"]

--- a/gitbook_worker/src/gitbook_worker/docker_cli.py
+++ b/gitbook_worker/src/gitbook_worker/docker_cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from .docker_tools import ensure_docker_image, ensure_docker_desktop
+
+
+IMAGE_NAME = "gitbook-worker"
+
+
+def main() -> None:
+    """Run gitbook-worker inside its Docker container."""
+    ensure_docker_desktop()
+    root_dir = Path(__file__).resolve().parents[2]
+    dockerfile = root_dir / "Dockerfile"
+    ensure_docker_image(IMAGE_NAME, str(dockerfile))
+
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{os.getcwd()}:/data",
+        "-w",
+        "/data",
+        IMAGE_NAME,
+    ] + sys.argv[1:]
+    subprocess.run(cmd, check=False)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- expand README usage notes for the new Docker setup
- add a `gitbook-worker-docker` helper script that runs the worker inside its container
- expose the helper via a new entrypoint in `pyproject.toml`

## Testing
- `pip install -e gitbook_worker`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68736ec3dd90832a81263165f5ac7588