### PR TITLE
Complete sprint 1 with CLI wrapper and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -e ./gitbook_worker
+          pip install pytest
+      - name: Run tests
+        run: pytest -q
+      - name: Build Docker image
+        run: docker build -t gitbook-worker .

--- a/README.md
+++ b/README.md
@@ -30,4 +30,11 @@ pip install -e gitbook_worker
 gitbook-worker-docker --help
 ```
 
+Alternatively you can call the `mycli.py` wrapper script directly without
+installing anything:
+
+```bash
+./mycli.py --help
+```
+
 Mount your working directories as needed to process a GitBook repository.

--- a/gitbook_worker/src/gitbook_worker/docker_cli.py
+++ b/gitbook_worker/src/gitbook_worker/docker_cli.py
@@ -11,12 +11,15 @@ from .docker_tools import ensure_docker_image, ensure_docker_desktop
 IMAGE_NAME = "gitbook-worker"
 
 
-def main() -> None:
+def main(args: list[str] | None = None) -> None:
     """Run gitbook-worker inside its Docker container."""
     ensure_docker_desktop()
     root_dir = Path(__file__).resolve().parents[2]
     dockerfile = root_dir / "Dockerfile"
     ensure_docker_image(IMAGE_NAME, str(dockerfile))
+
+    if args is None:
+        args = sys.argv[1:]
 
     cmd = [
         "docker",
@@ -27,7 +30,7 @@ def main() -> None:
         "-w",
         "/data",
         IMAGE_NAME,
-    ] + sys.argv[1:]
+    ] + list(args)
     subprocess.run(cmd, check=False)
 
 

--- a/gitbook_worker/tests/test_cli.py
+++ b/gitbook_worker/tests/test_cli.py
@@ -1,0 +1,48 @@
+import types
+import importlib.util
+from pathlib import Path
+from gitbook_worker.src.gitbook_worker import docker_cli
+
+MYCLI_PATH = Path(__file__).resolve().parents[2] / "mycli.py"
+spec = importlib.util.spec_from_file_location("mycli", MYCLI_PATH)
+mycli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mycli)
+
+
+def test_mycli_invokes_docker(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_run(cmd, check=False):
+        calls['cmd'] = cmd
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(docker_cli, 'ensure_docker_desktop', lambda: None)
+    monkeypatch.setattr(docker_cli, 'ensure_docker_image', lambda name, path: None)
+    monkeypatch.setattr(docker_cli.subprocess, 'run', fake_run)
+
+    mycli.main(['--help'])
+
+    assert calls['cmd'][0] == 'docker'
+    assert '-v' in calls['cmd']
+    vol_idx = calls['cmd'].index('-v') + 1
+    assert calls['cmd'][vol_idx].startswith(str(tmp_path))
+    assert docker_cli.IMAGE_NAME in calls['cmd']
+
+
+def test_mycli_passes_arguments(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_run(cmd, check=False):
+        calls['cmd'] = cmd
+        return types.SimpleNamespace(returncode=1)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(docker_cli, 'ensure_docker_desktop', lambda: None)
+    monkeypatch.setattr(docker_cli, 'ensure_docker_image', lambda name, path: None)
+    monkeypatch.setattr(docker_cli.subprocess, 'run', fake_run)
+
+    mycli.main(['--some', 'arg'])
+
+    assert '--some' in calls['cmd']
+    assert 'arg' in calls['cmd']

--- a/mycli.py
+++ b/mycli.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Convenience wrapper to run gitbook-worker via Docker."""
+from __future__ import annotations
+
+import sys
+from gitbook_worker.docker_cli import main as docker_main
+
+
+def main(args: list[str] | None = None) -> None:
+    docker_main(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- extend Docker CLI helper to accept argument list
- add `mycli.py` wrapper so the worker can run without installing the package
- document wrapper usage in the README
- provide end-to-end CLI tests
- set up GitHub Actions workflow running tests and building the Docker image

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873c0a8f1cc832a986ed4efa1688c6a