### PR TITLE
Implement sprint validation and publishing stability

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -1,7 +1,7 @@
 ---
-version: 1.0.0
-date: 2025-05-30
-history: Condensed root-level handbook derived from legacy docs and current CI setup.
+version: 1.1.0
+date: 2025-06-01
+history: Added contributor quickstart, troubleshooting, and Docker image guidance.
 ---
 
 # GitBook Worker Handbook
@@ -19,6 +19,17 @@ maintained reference. The legacy archive remains read-only for deep dives.
 - When editing YAML planning docs, keep the front matter (`version`, `date`, `history`) in sync with the change.
 - The deprecated `tools/` shim exists only for legacy imports—prefer `gitbook_worker.*` everywhere else.
 
+## Contributor quickstart
+- Install in editable mode: `pip install -e .` from the repository root.
+- Validate manifests quickly: `gitbook-worker validate --manifest publish.yml` (does not run the pipeline).
+- Run a local build: `./gitbook_worker/scripts/build-pdf.sh --profile local` or `gitbook-worker --profile default --manifest publish.yml`.
+- Execute targeted tests during iterations: `pytest tests/test_publisher.py tests/test_orchestrator_validate.py`.
+
+## Troubleshooting
+- If PDF output misses images, ensure the source directory is covered by Pandoc `--resource-path` (handled automatically by the publisher helper) and that assets live under `assets/` or `.gitbook/assets/`.
+- For font issues, confirm Twemoji/ERDA fonts are installed in the Docker image; the dynamic Dockerfile bundles them by default.
+- Enable verbose orchestrator analytics by reviewing log entries containing `Orchestrator analytics` after failures.
+
 ## CI guardrails
 - Unit tests enforce coverage via `pytest ... --cov=gitbook_worker --cov-fail-under=45` and publish `coverage.xml` as an artifact.
 - A dedicated `type-check` job runs `mypy` against the package on Python 3.12 with project dependencies installed.
@@ -27,6 +38,10 @@ maintained reference. The legacy archive remains read-only for deep dives.
 ## Publishing and fonts (field notes)
 - The dynamic Docker build installs TeX Live and Pandoc, then applies font setup driven by repository configuration rather than hardcoded fonts.
 - If integration tests report missing emoji or CJK fonts, ensure Twemoji and ERDA CC-BY CJK are available in the runner or rebuild the Docker image so the font check passes.
+
+## Docker usage paths
+- Prefer the dynamic image (`gitbook_worker/tools/docker/Dockerfile.dynamic`) for CI and local runs—it keeps font and LaTeX packages aligned with the publishing defaults.
+- The static image (`gitbook_worker/tools/docker/Dockerfile`) remains available for air-gapped hosts; pass `--no-build` to wrapper scripts only when the desired image tag already exists.
 
 ## Migration pointers
 - Treat `.github/gitbook_worker/docs/` as historical background; copy only distilled details back into this handbook.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ pip install -e .
 
 # Run the orchestrator with the default profile
 python -m gitbook_worker.tools.workflow_orchestrator --profile default --manifest publish.yml
+
+# Validate a manifest without running the pipeline
+gitbook-worker validate --manifest publish.yml
 ```
 
 ## Repository layout
@@ -27,7 +30,9 @@ python -m gitbook_worker.tools.workflow_orchestrator --profile default --manifes
 Workflows under `.github/workflows/` build the Docker image from
 `gitbook_worker/tools/docker/Dockerfile.dynamic` and call the same orchestrator
 entrypoint used locally. Copy or extend these workflows to integrate the package
-into other repositories.
+into other repositories. The static image (`gitbook_worker/tools/docker/Dockerfile`)
+remains available for air-gapped runners; the helper scripts default to the
+dynamic variant so font and LaTeX dependencies stay in sync with CI.
 
 ## Development
 

--- a/SPRINT_PLAN.md
+++ b/SPRINT_PLAN.md
@@ -1,7 +1,7 @@
 ---
-version: 1.0.4
+version: 1.0.5
 date: 2025-06-01
-history: Reset sprint for publishing stability and documentation automation.
+history: Completed sprint items (validation CLI, PDF stability, Docker docs, analytics, handbook refresh).
 ---
 
 # Sprint: Publishing stability & documentation automation
@@ -12,11 +12,11 @@ history: Reset sprint for publishing stability and documentation automation.
 - Automate handbook updates to reflect the package-first layout.
 
 ## Work items
-1. ☐ Stabilise font embedding and image handling in the PDF builder; add a smoke test in `tests/`.
-2. ☐ Introduce a fast CLI validation command (e.g., `gitbook-worker validate --manifest publish.yml`) wired into CI.
-3. ☐ Extend the handbook with a contributor quickstart and troubleshooting section aligned with `gitbook_worker/` entrypoints.
-4. ☐ Document Docker usage paths (dynamic vs. static images) and ensure build scripts reference current Dockerfiles.
-5. ☐ Capture failure analytics in logs for orchestrated jobs to simplify debugging.
+1. ☑ Stabilise font embedding and image handling in the PDF builder; add a smoke test in `tests/`.
+2. ☑ Introduce a fast CLI validation command (e.g., `gitbook-worker validate --manifest publish.yml`) wired into CI.
+3. ☑ Extend the handbook with a contributor quickstart and troubleshooting section aligned with `gitbook_worker/` entrypoints.
+4. ☑ Document Docker usage paths (dynamic vs. static images) and ensure build scripts reference current Dockerfiles.
+5. ☑ Capture failure analytics in logs for orchestrated jobs to simplify debugging.
 
 ## Risks / notes
 - PDF reproducibility depends on system fonts; ensure the Docker image pins font packages or bundles required assets.

--- a/gitbook_worker/scripts/run-in-docker.ps1
+++ b/gitbook_worker/scripts/run-in-docker.ps1
@@ -1,19 +1,28 @@
 # PowerShell Wrapper für Docker-basierte Tests und Workflows
-# Usage: .\run-in-docker.ps1 [test|orchestrator|shell]
+# Usage: .\run-in-docker.ps1 [test|orchestrator|shell] [-StaticImage] [-NoBuild]
 
 param(
     [Parameter(Mandatory=$true)]
     [ValidateSet("test", "test-slow", "orchestrator", "shell", "build-only")]
     [string]$Command,
-    
+
     [string]$Profile = "local",
-    [switch]$NoBuild
+    [switch]$NoBuild,
+    [switch]$StaticImage
 )
 
 $ErrorActionPreference = "Stop"
 
-$DOCKERFILE = "gitbook_worker/tools/docker/Dockerfile"
-$IMAGE_TAG = "erda-workflow-tools"
+$workDir = Get-Location
+
+if ($StaticImage) {
+    $DOCKERFILE = "gitbook_worker/tools/docker/Dockerfile"
+    $IMAGE_TAG = "erda-workflow-tools:static"
+} else {
+    $DOCKERFILE = "gitbook_worker/tools/docker/Dockerfile.dynamic"
+    $IMAGE_TAG = "erda-workflow-tools:dynamic"
+}
+Write-Host "Using Dockerfile: $DOCKERFILE"
 $CONTEXT = "."
 
 # Stelle sicher, dass Docker läuft

--- a/gitbook_worker/scripts/run-in-docker.sh
+++ b/gitbook_worker/scripts/run-in-docker.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 # Bash Wrapper für Docker-basierte Tests und Workflows
-# Usage: ./run-in-docker.sh [test|test-slow|orchestrator|shell|build-only] [--profile PROFILE] [--no-build]
+# Usage: ./run-in-docker.sh [test|test-slow|orchestrator|shell|build-only] [--profile PROFILE] [--no-build] [--static-image]
 
 set -e
 
 COMMAND=""
 PROFILE="local"
 NO_BUILD=0
+STATIC_IMAGE=0
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -23,6 +24,10 @@ while [[ $# -gt 0 ]]; do
             NO_BUILD=1
             shift
             ;;
+        --static-image)
+            STATIC_IMAGE=1
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
             echo "Usage: $0 [test|test-slow|orchestrator|shell|build-only] [--profile PROFILE] [--no-build]"
@@ -37,8 +42,14 @@ if [ -z "$COMMAND" ]; then
     exit 1
 fi
 
-DOCKERFILE="gitbook_worker/tools/docker/Dockerfile"
-IMAGE_TAG="erda-workflow-tools"
+if [ $STATIC_IMAGE -eq 1 ]; then
+    DOCKERFILE="gitbook_worker/tools/docker/Dockerfile"
+    IMAGE_TAG="erda-workflow-tools:static"
+else
+    DOCKERFILE="gitbook_worker/tools/docker/Dockerfile.dynamic"
+    IMAGE_TAG="erda-workflow-tools:dynamic"
+fi
+echo "Using Dockerfile: $DOCKERFILE"
 CONTEXT="."
 
 # Check Docker daemon

--- a/tests/test_orchestrator_validate.py
+++ b/tests/test_orchestrator_validate.py
@@ -1,0 +1,104 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from gitbook_worker.tools.workflow_orchestrator.orchestrator import (
+    DockerSettings,
+    OrchestratorConfig,
+    OrchestratorProfile,
+    STEP_HANDLERS,
+    run,
+    validate_manifest,
+)
+
+
+@pytest.fixture()
+def manifest_file(tmp_path: Path) -> Path:
+    manifest = tmp_path / "publish.yml"
+    manifest.write_text(
+        """
+version: 0.1.0
+profiles:
+  default:
+    steps:
+      - publisher
+""",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_validate_manifest_accepts_known_steps(manifest_file: Path):
+    ok, errors = validate_manifest(
+        root=manifest_file.parent,
+        manifest=manifest_file,
+        profile="default",
+        all_profiles=False,
+        repo_visibility="auto",
+        repository=None,
+    )
+
+    assert ok
+    assert errors == []
+
+
+def test_validate_manifest_flags_unknown_steps(manifest_file: Path):
+    manifest_file.write_text(
+        """
+version: 0.1.0
+profiles:
+  default:
+    steps:
+      - unknown-step
+""",
+        encoding="utf-8",
+    )
+
+    ok, errors = validate_manifest(
+        root=manifest_file.parent,
+        manifest=manifest_file,
+        profile="default",
+        all_profiles=False,
+        repo_visibility="auto",
+        repository=None,
+    )
+
+    assert not ok
+    assert any("unknown-step" in err for err in errors)
+
+
+def test_run_logs_failure_analytics(monkeypatch, caplog, manifest_file: Path):
+    failing_step = "__failing_step__"
+
+    def _fail(_ctx):
+        raise RuntimeError("boom")
+
+    caplog.set_level(logging.ERROR)
+    monkeypatch.setitem(STEP_HANDLERS, failing_step, _fail)
+    docker_settings = DockerSettings(use_registry=False, image=None, cache=False)
+    profile = OrchestratorProfile(
+        name="default",
+        steps=(failing_step,),
+        docker=docker_settings,
+    )
+    config = OrchestratorConfig(
+        root=manifest_file.parent,
+        manifest=manifest_file,
+        profile=profile,
+        repo_visibility="public",
+        repository=None,
+        commit=None,
+        base=None,
+        reset_others=False,
+        publisher_args=(),
+        dry_run=False,
+    )
+
+    with pytest.raises(RuntimeError):
+        run(config)
+
+    analytics_logs = [rec.message for rec in caplog.records if "analytics" in rec.message]
+    assert analytics_logs, "expected analytics log entry when step fails"
+
+    STEP_HANDLERS.pop(failing_step, None)


### PR DESCRIPTION
## Summary
- add a `gitbook-worker validate` subcommand with manifest profile checks and structured failure analytics logging for orchestrator runs
- stabilize PDF builds by prioritising source directories in resource paths, keep manual font fallback coverage, and add smoke tests
- refresh handbook/sprint documentation and point Docker wrapper scripts to the dynamic Dockerfile by default

## Testing
- pytest tests/test_publisher.py tests/test_orchestrator_validate.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca57904a0832ab40af8faa55a9ae0)