### PR TITLE
Fix local orchestrator launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,7 @@
                 "PYTHONUTF8": "1"
             },
             "args": [
+                "run",
                 "--root",
                 "${workspaceFolder}",
                 "--manifest",


### PR DESCRIPTION
## Summary
- add the required `run` subcommand to the VS Code launch configuration so the local orchestrator starts correctly

## Testing
- not run (not needed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d6bf25860832a916ee8d3572641dc)