### PR TITLE
Add neutral example book content

### DIFF
--- a/content/appendices/appendix-a.md
+++ b/content/appendices/appendix-a.md
@@ -1,0 +1,26 @@
+---
+title: Appendix A – Datenquellen und Tabellenlayout
+date: 2024-06-01
+version: 1.0
+---
+
+# Appendix A – Datenquellen und Tabellenlayout
+
+## A.1 Datenquellen
+1. Öffentliche Klimadatenkataloge regionaler Wetterdienste.
+2. Neutrale Beispielwerte aus firmeninternen Sandbox-Systemen.
+3. Internationale Open-Data-Repositorien wie [UN Data](https://data.un.org/) oder [World Bank Open Data](https://data.worldbank.org/).
+
+## A.2 Tabellenlayout
+| Spalte | Datentyp | Beschreibung |
+|--------|----------|--------------|
+| `timestamp` | ISO-8601 | Zeitstempel der Messung |
+| `metric` | String | Messgröße (Temperatur, Feuchte, etc.) |
+| `value` | Dezimalzahl | Gemessener Wert |
+| `unit` | String | Zugehörige Einheit |
+| `notes` | Freitext | Kontext oder Hinweise |
+
+## A.3 Weiterverwendung
+- Die Tabelle kann direkt in Dataframes importiert werden.
+- Nutze relative Links wie [Kapitel 2](../chapters/chapter-02.md) für Querverweise.
+- Grafiken finden sich im Verzeichnis [`content/images`](../images/).

--- a/content/chapters/chapter-01.md
+++ b/content/chapters/chapter-01.md
@@ -1,0 +1,30 @@
+---
+title: Kapitel 1 – Beobachtbare Muster
+date: 2024-06-01
+version: 1.0
+---
+
+# Kapitel 1 – Beobachtbare Muster
+
+Dieses Kapitel stellt eine neutrale Beschreibung strukturierter Beobachtungen vor. Alle Beispiele basieren auf generischen Messpunkten, die sich leicht in neue Kontexte übertragen lassen.
+
+## 1.1 Methodische Schritte
+1. **Rahmen definieren:** Bestimme den Zweck der Beobachtung (z. B. Temperatur, Nutzungsverhalten oder Prozessdauer).
+2. **Messpunkte wählen:** Lege neutrale Parameter fest, die keine personenbezogenen Daten enthalten.
+3. **Dokumentation sichern:** Halte Messergebnisse tabellarisch fest und verweise auf die Quelle, z. B. öffentliche Datenkataloge.[^1]
+
+## 1.2 Beispielbeschreibung
+- *Messgebiet:* Ein fiktives Versuchsareal mit moderatem Klima.
+- *Messgeräte:* Standardisierte Sensoren mit Kalibrierzertifikat.
+- *Auswertung:* Durchschnittswerte über einen Vier-Wochen-Zeitraum.
+
+Die resultierenden Daten werden weiter unten im Buch, insbesondere in [Kapitel 2](./chapter-02.md), in Tabellenform dargestellt. Detaildaten sind außerdem in [Appendix A](../appendices/appendix-a.md) abgelegt.
+
+## 1.3 Querverweise
+| Abschnitt | Zweck | Link |
+|-----------|-------|------|
+| Vorwort | Kontext und Zielsetzung | [Zur Einleitung](../preface.md) |
+| Bildvorlage | Grafische Darstellung | [Startseite](../index.md#visuale-vorschau) |
+| Textvorlagen | Mehrsprachige Snippets | [Templates](../templates/multilingual-neutral-text.md) |
+
+[^1]: Siehe [Zitationen & Quellen](../references.md).

--- a/content/chapters/chapter-02.md
+++ b/content/chapters/chapter-02.md
@@ -1,0 +1,32 @@
+---
+title: Kapitel 2 – Vergleichstabellen
+date: 2024-06-01
+version: 1.0
+---
+
+# Kapitel 2 – Vergleichstabellen
+
+Die folgenden Tabellen zeigen, wie neutrale Datensätze strukturiert werden können. Alle Werte sind illustrative Mittelwerte und lassen sich problemlos durch reale Messreihen ersetzen.
+
+## 2.1 Übersichtstabelle
+| Messpunkt | Woche 1 | Woche 2 | Woche 3 | Woche 4 |
+|-----------|---------|---------|---------|---------|
+| Temperaturmittel (°C) | 18.2 | 18.5 | 18.4 | 18.3 |
+| Luftfeuchte (%) | 52 | 53 | 51 | 52 |
+| Lichtstunden | 14 | 14 | 13 | 13 |
+
+## 2.2 Format-Beispiel für Verhältnisse
+| Kategorie | Anteil am Gesamtvolumen | Notiz |
+|-----------|------------------------|-------|
+| Messwerte mit direktem Sensorbezug | 40 % | Sensoren nach ISO 17025 kalibriert |
+| Berechnete Richtwerte | 35 % | Ableitung über gleitende Mittelwerte |
+| Kontextdaten | 25 % | Stammen aus öffentlichen Katalogen[^2] |
+
+Die Tabellen können als CSV exportiert oder in [Appendix A](../appendices/appendix-a.md#tabellenlayout) erneut eingesehen werden. Verlinke interne Abschnitte immer mit relativen Pfaden, damit das Buch offline funktioniert.
+
+## 2.3 Referenz auf Abbildungen
+![Rasterdarstellung der Messpunkte](../images/neutral-grid.svg)
+
+Die Abbildung verdeutlicht, wie Messzonen schematisch gezeigt werden können, ohne reale Orte zu benennen.
+
+[^2]: Vgl. die referenzierten offenen Kataloge in [Zitationen & weiterführende Quellen](../references.md).

--- a/content/images/neutral-grid.svg
+++ b/content/images/neutral-grid.svg
@@ -1,0 +1,12 @@
+<svg width="320" height="180" viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Neutral Grid Illustration</title>
+  <desc id="desc">A calm grid of shapes that does not depict any sensitive imagery.</desc>
+  <rect width="320" height="180" fill="#f5f5f5"/>
+  <g stroke="#8c8c8c" stroke-width="1" fill="none">
+    <path d="M40 20 H280"/><path d="M40 60 H280"/><path d="M40 100 H280"/><path d="M40 140 H280"/>
+    <path d="M40 20 V140"/><path d="M90 20 V140"/><path d="M140 20 V140"/><path d="M190 20 V140"/><path d="M240 20 V140"/><path d="M290 20 V140"/>
+  </g>
+  <circle cx="160" cy="80" r="28" fill="#d7e3f4" stroke="#5a6e8c" stroke-width="2"/>
+  <rect x="70" y="110" width="60" height="30" fill="#e6f2d9" stroke="#5f7a4b"/>
+  <rect x="190" y="110" width="60" height="30" fill="#f9e4d0" stroke="#a76a3d"/>
+</svg>

--- a/content/index.md
+++ b/content/index.md
@@ -1,0 +1,32 @@
+---
+title: Startseite
+description: Übersicht für das neutrale Beispielbuch
+date: 2024-06-01
+version: 1.0
+---
+
+# Willkommen zur neutralen Beispielbibliothek
+
+Diese Startseite liefert einen schnellen Überblick über das Beispielbuch, das als neutrale Vorlage für Tests, Layoutprüfungen und internationale Text-Snippets dient. Die Kapitel enthalten Tabellen, Bilder, interne und externe Links sowie strukturierte Anhänge.
+
+## Schnelleinstieg
+- [Vorwort](./preface.md)
+- [Kapitel 1 – Beobachtbare Muster](./chapters/chapter-01.md)
+- [Kapitel 2 – Vergleichstabellen](./chapters/chapter-02.md)
+- [Vorlagen für mehrsprachige Texte](./templates/multilingual-neutral-text.md)
+- [Appendix A – Datenquellen](./appendices/appendix-a.md)
+- [Zitationen & weiterführende Quellen](./references.md)
+
+## Visuale Vorschau
+![Neutrale Formen](./images/neutral-grid.svg)
+
+Die Illustration zeigt abstrakte Formen ohne Bezug zu realen Personen oder markenrechtlich relevanten Themen. Sie kann beliebig oft wiederverwendet werden, um Bildkomponenten zu testen.
+
+## Externe neutrale Links
+- [United Nations Data](https://data.un.org/)
+- [Smithsonian Open Access](https://www.si.edu/openaccess)
+- [World Meteorological Organization](https://public.wmo.int/en)
+
+Alle Links führen zu allgemein zugänglichen, neutralen Informationen und eignen sich für rechtlich unkritische Testfälle.
+
+> Tipp: Nutze die Startseite als Template, indem du die hier gelisteten Sektionen kopierst und für deine eigene Dokumentation anpasst.

--- a/content/placeholder.md
+++ b/content/placeholder.md
@@ -1,4 +1,3 @@
-# Placeholder content
+# Inhaltshinweis
 
-Temporary marker to keep content path resolution stable after the package
-relocation. Replace with real chapters when the new content structure lands.
+Der Content-Ordner enthält jetzt vollständige Beispielkapitel, Anhänge, Bilddateien und Vorlagen. Verwende [content/index.md](./index.md) als Startpunkt.

--- a/content/preface.md
+++ b/content/preface.md
@@ -1,0 +1,15 @@
+---
+title: Vorwort
+date: 2024-06-01
+version: 1.0
+---
+
+# Vorwort
+
+Dieses Vorwort erläutert Zweck und Aufbau des Beispielbuchs. Alle Inhalte sind bewusst neutral formuliert, damit sie für Usability-Tests, Layout-Demos und Lokalisierungsworkflows genutzt werden können.
+
+- **Zielgruppe:** Teams, die Text-, Bild- oder Tabellenkomponenten ohne reale Kundendaten testen möchten.
+- **Struktur:** Jede Sektion enthält mindestens ein Element, das in typischen Buchproduktionen vorkommt – z. B. Abbildungen, Querverweise, Zitationen oder Tabellen.
+- **Internationalität:** Die beiliegende Vorlage für mehrsprachige Texte deckt gängige Hauptsprachen ab und kann erweitert werden.
+
+Weiterführende Hinweise finden sich in [Kapitel 1](./chapters/chapter-01.md), während [Kapitel 2](./chapters/chapter-02.md) konkrete Tabellenlayouts bietet.

--- a/content/references.md
+++ b/content/references.md
@@ -1,0 +1,14 @@
+---
+title: Zitationen & weiterführende Quellen
+date: 2024-06-01
+version: 1.0
+---
+
+# Zitationen & weiterführende Quellen
+
+1. **United Nations Data Portal.** Zugriff am 01.06.2024. https://data.un.org/
+2. **World Bank Open Data.** Zugriff am 01.06.2024. https://data.worldbank.org/
+3. **World Meteorological Organization – Public Resources.** Zugriff am 01.06.2024. https://public.wmo.int/en
+4. **Smithsonian Open Access.** Zugriff am 01.06.2024. https://www.si.edu/openaccess
+
+Verweise innerhalb des Buchs nutzen nummerierte Fußnoten, um konsistent auf diese Liste zu zeigen.

--- a/content/templates/multilingual-neutral-text.md
+++ b/content/templates/multilingual-neutral-text.md
@@ -1,0 +1,149 @@
+---
+title: Vorlage für mehrsprachige neutrale Texte
+date: 2024-06-02
+version: 1.1
+---
+
+# Vorlage für mehrsprachige neutrale Texte
+
+Die folgende Struktur zeigt, wie neutrale Textbausteine in mehreren Sprachen formuliert werden können. Verwende kurze Sätze, verzichte auf personenbezogene Details und vermeide kultur- oder markenspezifische Begriffe.
+
+## Grundaufbau
+```
+## Kontext
+Kurze Beschreibung des Szenarios.
+
+### Sprache (ISO-Code)
+Neutraler Absatz.
+```
+
+## Beispiel: Globale Wetterbeobachtung
+- **Kontext:** Ein Team beschreibt einen ruhigen Tag mit moderaten Wetterwerten.
+
+### Deutsch (de)
+Ein moderater Morgen brachte gleichmäßige Temperaturen, wodurch Messgeräte ohne Anpassung betrieben werden konnten.
+
+### Englisch (en)
+The observation team noted a calm day with stable readings, enabling straightforward comparisons over the week.
+
+### Französisch (fr)
+L'équipe a enregistré une journée stable, ce qui facilite la comparaison avec les mesures précédentes.
+
+### Spanisch (es)
+El equipo observó un día sereno con datos regulares que permiten revisar tendencias sin sesgos.
+
+### Portugiesisch (pt)
+A equipe registrou um período estável, adequado para validar calibragens e rotinas de manutenção.
+
+### Italienisch (it)
+Il gruppo ha descritto una giornata equilibrata, utile per mantenere le serie temporali coerenti.
+
+### Niederländisch (nl)
+Het team rapporteerde een rustige dag met meetwaarden die zonder correcties konden worden vastgelegd.
+
+### Bulgarisch (bg)
+Екипът отбеляза спокоен ден с равномерни данни, което улеснява сравненията в рамките на седмицата.
+
+### Kroatisch (hr)
+Tim je zabilježio miran dan s ujednačenim vrijednostima koje pojednostavljuju usporedbe tijekom tjedna.
+
+### Tschechisch (cs)
+Tým zaznamenal klidný den se stabilními hodnotami, takže týdenní porovnání probíhá bez úprav.
+
+### Dänisch (da)
+Holdet noterede en rolig dag med jævne målinger, hvilket gør det let at sammenligne ugens værdier.
+
+### Estnisch (et)
+Meeskond kirjeldas rahulikku päeva ühtlaste näitudega, mis hõlbustab nädalate võrdlemist.
+
+### Finnisch (fi)
+Tiimi mukaan päivä oli tasainen ja mittaukset pysyivät muuttumattomina, mikä tukee vertailevaa seurantaa.
+
+### Griechisch (el)
+Η ομάδα κατέγραψε ήρεμη ημέρα με σταθερές μετρήσεις που διευκολύνουν τις εβδομαδιαίες συγκρίσεις.
+
+### Ungarisch (hu)
+A csapat nyugodt napot írt le, amelynek mérései stabilak maradtak, így könnyű a heti összevetés.
+
+### Irisch (ga)
+Luaigh an fhoireann lá ciúin le léamha cobhsaí a éascaíonn comparáidí seachtainiúla.
+
+### Lettisch (lv)
+Komanda aprakstīja mierīgu dienu ar vienmērīgiem rādījumiem, kas atvieglo salīdzināšanu nedēļas griezumā.
+
+### Litauisch (lt)
+Komanda užfiksavo ramią dieną su stabiliais duomenimis, todėl savaitiniai palyginimai yra paprasti.
+
+### Maltesisch (mt)
+It-tim irreġistra ġurnata kwieta b'qari stabbli li jagħmlu aktar faċli li tqabbel id-dejta tal-ġimgħa.
+
+### Polnisch (pl)
+Zespół odnotował spokojny dzień ze stałymi odczytami, co ułatwia porównania tygodniowe.
+
+### Rumänisch (ro)
+Echipa a remarcat o zi calmă cu valori stabile, ușurând comparațiile din cursul săptămânii.
+
+### Slowakisch (sk)
+Tím opísal pokojný deň so stabilnými údajmi, ktoré pomáhajú pri porovnávaní v rámci týždňa.
+
+### Slowenisch (sl)
+Ekipa je opisala miren dan z enakomernimi meritvami, kar olajša tedenske primerjave.
+
+### Schwedisch (sv)
+Teamet noterade en lugn dag med stabila värden som gör jämförelser under veckan enklare.
+
+### Ukrainisch (uk)
+Команда спостерігала спокійний день зі стабільними показниками, що спрощує тижневі порівняння.
+
+### Arabisch (ar)
+سجل الفريق يوماً هادئاً بقراءات مستقرة تسهّل مقارنة البيانات خلال الأسبوع.
+
+### Chinesisch (zh)
+观测团队记录了一个稳定的日子，数据平稳，有助于持续对比不同周的趋势。
+
+### Japanisch (ja)
+観測チームは穏やかな一日を記録し、安定したデータが週次比較を容易にすると述べました。
+
+### Süd-Koreanisch (ko)
+관측 팀은 측정값이 고르게 유지된 차분한 하루를 기록하여 주간 비교가 수월해졌다고 보고했습니다.
+
+### Hindi (hi)
+टीम ने एक शांत दिन दर्ज किया जहाँ मान स्थिर रहे और साप्ताहिक तुलना सरल हो गई।
+
+### Indonesisch (id)
+Tim melaporkan hari tenang dengan bacaan stabil sehingga peninjauan mingguan dapat dilakukan tanpa penyesuaian.
+
+### Filipino (fil)
+Iniulat ng koponan ang isang mahinahong araw na may pantay na datos, kaya mas madali ang paghahambing ng lingguhan.
+
+### Māori (mi)
+I tuhi te rōpū tirotiro i tētahi rā mārie me ngā uara tōtika, he mea māmā ai te whakataurite ā-wiki.
+
+### Samoanisch (sm)
+Na fa'amau e le 'au se aso filemu ma faitauga toniga e faafaigofie ai su'esu'ega o vaiaso ta'itasi.
+
+### Swahili (sw)
+Timu ilieleza siku tulivu yenye takwimu thabiti zinazorahisisha kulinganisha kwa wiki.
+
+### Amharisch (am)
+ቡድኑ በተመጣጣኝ መዝገቦች ያለ የተረጋጋ ቀን መመዝገቡን አግልፆ እርምጃዎችን ለአስተካክል ቀላል እንደሚያደርግ ገለጸ።
+
+### Yoruba (yo)
+Ẹgbẹ́ náà sọ pé ọjọ́ naa dakẹ́ nígbà tí àwọ́n ìwọn ṣetán bí wọ́n ṣe rí, kí iṣirò ọ̀sẹ̀ rọrùn.
+
+### Hausa (ha)
+Ƙungiyar ta lura da ranar natsuwa mai daidaitattun bayanai da ke sauƙaƙa kwatancen mako-mako.
+
+### Inuktitut (iu)
+ᐊᒥᓱᓂ ᐱᒋᐊᕐᔪᖅ ᐅᑭᐅᑎᖅ ᐃᒡᓗᓕᖅ ᑐᙵᓇᐅᑎᓪᓗᓂ ᐱᖃᓗᒍ ᐅᓇ ᐃᓄᖅᑐᐊᓕᕐᓂᖅ ᑐᓴᖅᑕᐅᔪᒥ.
+
+### Türkisch (tr)
+Ekip, ölçümlerin dengede kaldığı sakin bir gün bildirerek haftalık karşılaştırmaların kolaylaştığını belirtti.
+
+### Aserbaidschanisch (az)
+Komanda sabit göstəricilərlə sakit bir gün qeydə aldı və bu da həftəlik müqayisələri sadələşdirir.
+
+### Kasachisch (kk)
+Топ тұрақты көрсеткіштер сақталған тыныш күнді сипаттап, апталық салыстыруды жеңілдететінін айтты.
+
+Diese Auflistung kann beliebig erweitert werden. Ergänze bei Bedarf Hinweise zum Schriftsystem oder zur Leserichtung (z. B. bei Arabisch oder Hebräisch).


### PR DESCRIPTION
## Summary
- add a fully linked start page, preface, chapters, appendix, and references for the sample book
- provide multilingual neutral text templates, neutral tables, and external/internal links for testing, now covering all EU languages plus added Japanese, Korean, Ukrainian, Inuit, Turkic, African, and Indo-Pacific examples while removing Russian
- include an accessible neutral SVG illustration and update the placeholder file to point to the new structure

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d8674e7ac832aa8152bbbe1daf7f8)