### PR TITLE
Add emoji example pages and font coverage appendix

### DIFF
--- a/content/appendices/emoji-font-coverage.md
+++ b/content/appendices/emoji-font-coverage.md
@@ -1,0 +1,34 @@
+---
+title: Appendix – Emoji- & Schriftabdeckung
+description: Nachweis geeigneter Fonts für alle Schriftzeichen und farbigen Emojis im Beispielinhalt.
+date: 2024-06-05
+version: 1.0
+history:
+  - version: 1.0
+    date: 2024-06-05
+    changes: Erstfassung mit Font-Matrix und Testhinweisen.
+---
+
+# Appendix – Emoji- & Schriftabdeckung
+
+Diese Übersicht fasst die Fonts zusammen, die sämtliche Schriftsysteme der Beispieltexte sowie alle Emoji-Sets abdecken. Alle Fonts erfüllen die Lizenzanforderungen aus `AGENTS.md` und der Datei `LICENSE-FONTS`.
+
+## Font-Matrix
+
+| Kategorie | Font | Lizenz | Quelle | Abdeckung |
+| --- | --- | --- | --- | --- |
+| Serif/Sans/Mono | DejaVu Serif · DejaVu Sans · DejaVu Sans Mono (v2.37) | Bitstream Vera License + Public-Domain-Erweiterungen | `gitbook_worker/defaults/fonts.yml` · `publish/ATTRIBUTION.md` | Latein, Griechisch, Kyrillisch sowie technische Symbole für Tabellen und Code |
+| CJK & weitere BMP-Glyphen | ERDA CC-BY CJK | CC BY 4.0 **oder** MIT | `.github/fonts/erda-ccby-cjk` · `LICENSE-FONTS` | Chinesisch, Japanisch, Koreanisch und zusätzliche Unicode-Blöcke aus den mehrsprachigen Vorlagen |
+| Farbige Emojis | Twemoji Color Font v15.1.0 | CC BY 4.0 | https://github.com/13rac1/twemoji-color-font/releases/tag/v15.1.0 · `publish/ATTRIBUTION.md` | Alle Emoji-Kategorien einschließlich Hauttöne, ZWJ-Sequenzen und Flaggen |
+
+## Praktische Nutzung
+
+1. **Textabschnitte** – Die DejaVu-Familie fungiert als Standard für Fließtext (`SERIF`), UI-Elemente (`SANS`) und Code (`MONO`). Dadurch sind sämtliche europäischen Sprachen der Datei `content/templates/multilingual-neutral-text.md` abgedeckt.
+2. **CJK** – Sobald Kapitel oder Beispielseiten Schriftzeichen wie 日, 学 oder 정보 verwenden, sollte das Build-System die ERDA-CC-BY-CJK-Datei aus `.github/fonts/erda-ccby-cjk/true-type/` einbetten. Das geschieht automatisch über die `CJK`-Sektion in `gitbook_worker/defaults/fonts.yml`.
+3. **Emoji-Farbe** – Für die neuen Emoji-Beispielseiten wird der Twemoji-Color-Font eingebunden. Die Datei `gitbook_worker/defaults/fonts.yml` verweist auf die Download-URL, sodass CI-Builds das TTF automatisiert nachladen können.
+
+## Testhinweise
+
+- Führe `pytest -k emoji` aus, um sicherzustellen, dass das Font-Scanning keine unbekannten Schriften meldet.
+- Prüfe PDF-Exports mit mindestens einer Seite aus jeder Emoji-Kategorie (Smileys, Natur, Aktivitäten, Objekte), um Twemoji gegen CJK-Text zu testen.
+- Dokumentiere neue Fonts zusätzlich in `publish/ATTRIBUTION.md` und `LICENSE-FONTS`, falls weitere Schriftsysteme hinzukommen.

--- a/content/examples/emoji-activities-and-travel.md
+++ b/content/examples/emoji-activities-and-travel.md
@@ -1,0 +1,50 @@
+---
+title: Emoji-Beispiele – Aktivitäten & Reisen
+description: Häufige Sport-, Freizeit- und Transport-Emojis für Funktions- und Renderingtests.
+date: 2024-06-05
+version: 1.0
+history:
+  - version: 1.0
+    date: 2024-06-05
+    changes: Startversion für Aktivitäten- und Verkehrsgruppen.
+---
+
+# Emoji-Beispiele – Aktivitäten & Reisen
+
+Diese Sammlung kombiniert Sport, Hobbys, Büro-Workflows und Transportmittel, damit Workflows mit kombinierten Emojis getestet werden können.
+
+## Sport & Fitness
+
+| Kategorie | Emoji | Unicode | Hinweis |
+| --- | --- | --- | --- |
+| Ausdauer | 🏃‍♀️ 🏃‍♂️ 🚴‍♀️ 🚴‍♂️ 🏊‍♀️ 🏊‍♂️ | Person + Variation Selector | Lauf-, Rad- und Schwimm-Events |
+| Teamsport | ⚽ 🏀 🏐 🏈 ⚾ 🥎 | U+26BD · U+1F3C0 · U+1F3D0 · U+1F3C8 · U+26BE · U+1F94E | Ballspiele |
+| Präzision | 🏓 🏸 🏑 🤺 🎯 | U+1F3D3 · U+1F3F8 · U+1F3D1 · U+1F93A · U+1F3AF | Schläger-, Fecht- und Zielübungen |
+| Wintersport | ⛷️ 🏂 ⛸️ 🛷 🥌 | U+26F7 · U+1F3C2 · U+26F8 · U+1F6F7 · U+1F94C | Schnee- und Eisdisziplinen |
+| Siege | 🏅 🥇 🥈 🥉 🏆 | U+1F3C5 · U+1F947 · U+1F948 · U+1F949 · U+1F3C6 | Auszeichnungen |
+
+## Kultur & Freizeit
+
+| Thema | Emoji | Unicode | Beschreibung |
+| --- | --- | --- | --- |
+| Musik | 🎧 🎤 🎸 🎻 🎹 🥁 | U+1F3A7 · U+1F3A4 · U+1F3B8 · U+1F3BB · U+1F3B9 · U+1F941 | Audio- und Instrumententests |
+| Kunst & Medien | 🎨 🖌️ 🖼️ 🎬 🎞️ | U+1F3A8 · U+1F58C · U+1F5BC · U+1F3AC · U+1F39E | Kreativbereiche |
+| Spiele | 🎮 ♟️ 🎲 🧩 🃏 | U+1F3AE · U+265F · U+1F3B2 · U+1F9E9 · U+1F0CF | Game- und Puzzlebeispiele |
+| Lernen | 📚 🧪 🧬 🧠 📐 | U+1F4DA · U+1F9EA · U+1F9EC · U+1F9E0 · U+1F4D0 | Bildungs- und Labor-Inhalte |
+| Büro | 💻 🖥️ 🖨️ 📠 📸 | U+1F4BB · U+1F5A5 · U+1F5A8 · U+1F4E0 · U+1F4F8 | Remote- und Studio-Workflows |
+
+## Reisen & Infrastruktur
+
+| Kategorie | Emoji | Unicode | Kontext |
+| --- | --- | --- | --- |
+| Landverkehr | 🚗 🚙 🚌 🚎 🚚 🚛 🚜 | U+1F697–U+1F69C | Straßenfahrzeuge |
+| Bahn | 🚆 🚇 🚈 🚊 🚉 | U+1F686 · U+1F687 · U+1F688 · U+1F68A · U+1F689 | Bahntypen |
+| Luftfahrt | ✈️ 🛫 🛬 🚁 🛩️ | U+2708 · U+1F6EB · U+1F6EC · U+1F681 · U+1F6E9 | Flugbewegungen |
+| Wasser | ⛴️ 🚢 🛳️ 🚤 🛶 | U+26F4 · U+1F6A2 · U+1F6F3 · U+1F6A4 · U+1F6F6 | Schiffe & Freizeitboote |
+| Infrastruktur | 🛣️ 🛤️ 🛫 🧭 🗺️ | U+1F6E3 · U+1F6E4 · U+1F6EB · U+1F9ED · U+1F5FA | Navigation |
+
+## Hinweise für Tests
+
+- Transport-Emojis verursachen oft höhere Zeilenhöhen; verwende daher Tabellen mit fixer Höhe, wenn Layouttests reproduzierbar sein sollen.
+- Nutze Mehrspalten-Layouts, damit die Twemoji-Color-Font bei dicht gepackten Abschnitten richtig anti-aliased wird.
+- Kombiniere Sport- und Reiseabschnitte, um Interaktionen zwischen Personen-ZWJ-Sequenzen und Piktogrammen zu überprüfen.

--- a/content/examples/emoji-nature-and-food.md
+++ b/content/examples/emoji-nature-and-food.md
@@ -1,0 +1,50 @@
+---
+title: Emoji-Beispiele – Natur & Essen
+description: Sammlung gängiger Natur-, Tier- und Lebensmittel-Emojis für Layouttests.
+date: 2024-06-05
+version: 1.0
+history:
+  - version: 1.0
+    date: 2024-06-05
+    changes: Erste Veröffentlichung für Natur- und Ernährungsgruppen.
+---
+
+# Emoji-Beispiele – Natur & Essen
+
+Diese Referenzseite deckt Pflanzen, Wetterereignisse, Tiere und Lebensmittel ab. Nutze die Gruppen, um Farbkontraste und Textumbruch mit mehrfarbigen Glyphen zu prüfen.
+
+## Wetter & Umwelt
+
+| Thema | Emoji | Unicode | Beschreibung |
+| --- | --- | --- | --- |
+| Wetter | ☀️ 🌤️ ⛅ 🌧️ ⛈️ 🌩️ 🌪️ | U+2600 · U+1F324–U+1F32A | Neutrale meteorologische Symbole |
+| Himmel | 🌈 🌙 ⭐ 🌌 🌠 | U+1F308 · U+1F319 · U+2B50 · U+1F30C · U+1F320 | Licht- und Nachtmotive |
+| Erde | 🌍 🌎 🌏 🌐 🧭 | U+1F30D · U+1F30E · U+1F30F · U+1F310 · U+1F9ED | Globale Darstellungen |
+| Pflanzen | 🌱 🌿 ☘️ 🍀 🌳 🌵 | U+1F331 · U+1F33F · U+2618 · U+1F340 · U+1F333 · U+1F335 | Vegetations-Typen |
+| Elemente | 🔥 💧 🪨 🌀 🌫️ | U+1F525 · U+1F4A7 · U+1FAA8 · U+1F300 · U+1F32B | Grundelemente & Effekte |
+
+## Tiere
+
+| Kategorie | Emoji | Unicode | Besonderheit |
+| --- | --- | --- | --- |
+| Säugetiere | 🐶 🐱 🐭 🐹 🐰 🦊 🐻 | U+1F436–U+1F43B | Haustiere und Waldtiere |
+| Vögel | 🐦 🦅 🐧 🦜 🦢 | U+1F426 · U+1F985 · U+1F427 · U+1F99C · U+1F9A2 | Flug- und Wassertiere |
+| Reptilien & Amphibien | 🐢 🐍 🦎 🐸 | U+1F422 · U+1F40D · U+1F98E · U+1F438 | Terrarien und Naturkundemotive |
+| Insekten | 🐝 🐞 🦋 🐜 🦟 | U+1F41D · U+1F41E · U+1F98B · U+1F41C · U+1F99F | Bestäubung und Biologie |
+| Wasserleben | 🐟 🐠 🐡 🐬 🐳 🐙 | U+1F41F · U+1F420 · U+1F421 · U+1F42C · U+1F433 · U+1F419 | Aquatische Vielfalt |
+
+## Lebensmittel & Getränke
+
+| Kategorie | Emoji | Unicode | Beschreibung |
+| --- | --- | --- | --- |
+| Obst | 🍎 🍊 🍌 🍇 🍓 🥝 🍍 | U+1F34E–U+1F34A · U+1F34C · U+1F347 · U+1F353 · U+1F34F · U+1F34D | Früchte mit klaren Farben |
+| Gemüse | 🥕 🥦 🧅 🧄 🌽 🥔 | U+1F955 · U+1F966 · U+1F9C5 · U+1F9C4 · U+1F33D · U+1F954 | Nahrungsvielfalt |
+| Grundnahrung | 🍞 🥐 🥨 🥯 🍚 🍝 | U+1F35E · U+1F950 · U+1F968 · U+1F96F · U+1F35A · U+1F35D | Getreide- und Pastagerichte |
+| Snacks | 🍿 🍪 🍩 🍰 🧁 🍫 | U+1F37F · U+1F36A · U+1F369 · U+1F370 · U+1F9C1 · U+1F36B | Süße Beispiele |
+| Getränke | ☕ 🍵 🥤 🧃 🍺 🍷 🍶 | U+2615 · U+1F375 · U+1F964 · U+1F9C3 · U+1F37A · U+1F377 · U+1F376 | Heiße und kalte Getränke |
+
+## Hinweise für Tests
+
+- Kombiniere Pflanzen- oder Tierabschnitte mit den mehrsprachigen Textvorlagen, um Zeilenumbrüche in anderen Schriftsystemen zu prüfen.
+- Verwende dunkle und helle Hintergrundfarben, um sicherzustellen, dass die Farbebenen der Emojis mit dem Twemoji-Color-Font korrekt übereinanderliegen.
+- Teste Druckausgaben zusätzlich in Graustufen, um Kontraste zu bewerten.

--- a/content/examples/emoji-objects-symbols-flags.md
+++ b/content/examples/emoji-objects-symbols-flags.md
@@ -1,0 +1,50 @@
+---
+title: Emoji-Beispiele – Objekte, Symbole & Flaggen
+description: Referenzlisten für Werkzeuge, Technologie, Symbole und Flaggen mit vollständiger Emoji-Abdeckung.
+date: 2024-06-05
+version: 1.0
+history:
+  - version: 1.0
+    date: 2024-06-05
+    changes: Neu angelegte Seite für Objekte, Symbole und Flaggen.
+---
+
+# Emoji-Beispiele – Objekte, Symbole & Flaggen
+
+Diese Seite deckt Gebrauchsgegenstände, Symbole und internationale Flaggen ab und dient als Ergänzung zu den anderen Emoji-Beispielsammlungen.
+
+## Werkzeuge & Geräte
+
+| Kategorie | Emoji | Unicode | Beschreibung |
+| --- | --- | --- | --- |
+| Werkstatt | 🛠️ 🔧 🔩 ⚙️ 🪛 | U+1F6E0 · U+1F527 · U+1F529 · U+2699 · U+1FA9B | Mechanische Komponenten |
+| Labor | 🔬 🔭 ⚗️ 🧪 🧫 | U+1F52C · U+1F52D · U+2697 · U+1F9EA · U+1F9EB | Forschung und Analyse |
+| Kommunikation | 📱 📲 📞 📡 🛰️ | U+1F4F1 · U+1F4F2 · U+1F4DE · U+1F4E1 · U+1F6F0 | Funk- und Satellitensymbole |
+| Haushalt | 🧹 🧺 🧼 🪣 🪟 | U+1F9F9 · U+1F9FA · U+1F9FC · U+1FAA3 · U+1FA9F | Reinigungs- und Haushaltsgeräte |
+| Energie | 💡 🔋 🔌 ♻️ 🔦 | U+1F4A1 · U+1F50B · U+1F50C · U+267B · U+1F526 | Strom- und Nachhaltigkeitsicons |
+
+## Symbole & Zeichen
+
+| Typ | Emoji | Unicode | Bedeutung |
+| --- | --- | --- | --- |
+| Warnung | ⚠️ 🚸 ⛔ 🚫 ❗ ❕ | U+26A0 · U+1F6B8 · U+26D4 · U+1F6AB · U+2757 · U+2755 | Sicherheitssymbole |
+| Navigation | ⛳ 🎯 🧭 🧭 🗺️ | U+26F3 · U+1F3AF · U+1F9ED · (dupl.) · U+1F5FA | Orientierung (inkl. absichtlicher Dopplung für Redundanztests) |
+| Zeit | ⏱️ ⏲️ ⏰ 🕰️ 🗓️ | U+23F1 · U+23F2 · U+23F0 · U+1F570 · U+1F5D3 | Timer & Kalender |
+| Formen | ⬛ 🟦 ⬜ 🟥 🟨 🟩 🟧 | U+2B1B · U+1F7E6 · U+2B1C · U+1F7E5 · U+1F7E8 · U+1F7E9 · U+1F7E7 | Flächentest |
+| Religion | ☮️ ☯️ ✝️ ☪️ 🕉️ ✡️ | U+262E · U+262F · U+271D · U+262A · U+1F549 · U+2721 | Spirituelle Symbole |
+
+## Flaggen
+
+| Region | Emoji | Beschreibung |
+| --- | --- | --- |
+| Global | 🏳️ 🏴 🏁 🏳️‍🌈 🏳️‍⚧️ | Grundsymbole inkl. Pride-Varianten |
+| Europa | 🇪🇺 🇩🇪 🇫🇷 🇪🇸 🇮🇹 🇵🇱 🇸🇪 | EU- und Länderflaggen |
+| Amerika | 🇺🇳 🇺🇸 🇨🇦 🇧🇷 🇦🇷 🇨🇱 | Vereinte Nationen & Amerikas |
+| Afrika | 🇪🇬 🇳🇬 🇰🇪 🇿🇦 🇪🇹 | Nord-, West-, Ost- und Südafrika |
+| Asien & Ozeanien | 🇨🇳 🇯🇵 🇰🇷 🇮🇳 🇦🇺 🇳🇿 | Asiatisch-pazifische Staaten |
+
+## Hinweise für Tests
+
+- Flaggen bestehen aus regionalen Indikator-Symbolen (RIS); stelle sicher, dass der eingesetzte Font die Sequenzen korrekt kombiniert.
+- Verifiziere, dass Tabellen mit Symbolen und Werkzeugen über den **DejaVu**-Satz oder eine andere lizenzkonforme Serif/Sans-Lösung gerendert werden.
+- Für farbige Emojis empfiehlt sich weiterhin der Twemoji-Color-Font. In PDF-Workflows sollte `fonts.yml` als Referenz dienen, damit ZWJ-Sequenzen eingebunden werden.

--- a/content/examples/emoji-smileys-and-people.md
+++ b/content/examples/emoji-smileys-and-people.md
@@ -1,0 +1,51 @@
+---
+title: Emoji-Beispiele – Smileys & Personen
+description: Übersicht über klassische Gesichts- und Personen-Emojis zur Testabdeckung.
+date: 2024-06-05
+version: 1.0
+history:
+  - version: 1.0
+    date: 2024-06-05
+    changes: Erste Sammlung für Gesichter, Gesten und Rollenprofile.
+---
+
+# Emoji-Beispiele – Smileys & Personen
+
+Diese Seite gruppiert häufig genutzte Emoji-Sets nach Emotionen, Gesten und Rollenprofilen. Sie dient als Referenz, um Layouts, Schriftarten und Emoji-Fallbacks zu testen.
+
+## Smileys & Emotionen
+
+| Kategorie | Emoji | Unicode | Kurzbeschreibung |
+| --- | --- | --- | --- |
+| Fröhlich | 😀 😃 😄 😁 😆 😅 | U+1F600–U+1F606 | Standard-Smileys für positive Reaktionen |
+| Liebevoll | 😊 🥰 😍 😘 😻 | U+1F60A · U+1F970 · U+1F60D · U+1F618 · U+1F63B | Herzliche Reaktionen und Tier-Varianten |
+| Überraschung | 🤩 😮 😯 😲 🥳 | U+1F929 · U+1F62E · U+1F62F · U+1F632 · U+1F973 | Staunen und Party-Stimmung |
+| Nachdenklich | 🤔 😐 😑 😶 🤨 | U+1F914 · U+1F610 · U+1F611 · U+1F636 · U+1F928 | Neutrale oder skeptische Gesichter |
+| Stress | 😰 😱 😨 😢 😭 | U+1F630 · U+1F631 · U+1F628 · U+1F622 · U+1F62D | Stress, Sorge und Traurigkeit |
+| Gesundheit | 🤒 🤕 🤧 😷 😴 | U+1F912 · U+1F915 · U+1F927 · U+1F637 · U+1F634 | Medizinische Emojis und Schlaf |
+
+## Gesten & Hände
+
+| Typ | Emoji | Unicode | Zweck |
+| --- | --- | --- | --- |
+| Zustimmung | 👍 👏 🤝 🙌 | U+1F44D · U+1F44F · U+1F91D · U+1F64C | Zustimmung und Kooperation |
+| Ablehnung | 👎 🙅 🙅‍♂️ 🙅‍♀️ | U+1F44E · U+1F645 · ZWJ-Sequenzen | Verneinung und Abbruch |
+| Hinweise | ☝️ ✍️ 👉 👈 👆 👇 | U+261D · U+270D · U+1F449 · U+1F448 · U+1F446 · U+1F447 | Zeigende Gesten |
+| Kultur | 🤲 👐 🤘 🤙 🤟 | U+1F932 · U+1F450 · U+1F918 · U+1F919 · U+1F91F | Begrüßung und Musik-Gesten |
+| Inklusiv | ✋ ✋🏻 ✋🏽 ✋🏿 | U+270B + Fitzpatrick Modifiers | Hauttöne zur Barrierefreiheit |
+
+## Personen & Rollen
+
+| Kategorie | Emoji | Unicode | Beschreibung |
+| --- | --- | --- | --- |
+| Alltag | 🙂 🧑‍🦰 🧑‍🦱 🧑‍🦳 | Standardgesicht und Haarvarianten | Gesichtszüge mit neutralen Farben |
+| Beruf | 👩‍💻 👨‍🔧 🧑‍🏫 🧑‍🌾 | ZWJ-Sequenzen | Berufliche Darstellungen |
+| Familie | 👨‍👩‍👧 👩‍👧‍👦 👨‍👨‍👧‍👦 | Familien-ZWJ | Diversität in Haushalten |
+| Hilfsdienste | 👩‍🚒 👮‍♂️ 🧑‍🚀 🧑‍⚕️ | ZWJ-Sequenzen | Uniformen und Service |
+| Diversität | 🧕 🧔‍♂️ 🧑‍🦽 🧑‍🦯 | U+1F93F etc. | Kultur- und Assistenzbeispiele |
+
+## Hinweise für Tests
+
+- Kombiniere diese Emoji-Zeilen mit Textblöcken in verschiedenen Schriftsystemen, um Wechselwirkungen mit Zeilenhöhen zu prüfen.
+- Für farbige Glyphen empfiehlt sich das Einbinden der **Twemoji Color Font**; für monochrome Tests kann Twemoji in Graustufen gerendert werden.
+- Ergänze weitere Emojis mit ZWJ- oder Hautton-Modifikatoren, wenn spezifische Workflows dies erfordern.

--- a/content/index.md
+++ b/content/index.md
@@ -15,6 +15,11 @@ Diese Startseite liefert einen schnellen Überblick über das Beispielbuch, das 
 - [Kapitel 2 – Vergleichstabellen](./chapters/chapter-02.md)
 - [Vorlagen für mehrsprachige Texte](./templates/multilingual-neutral-text.md)
 - [Appendix A – Datenquellen](./appendices/appendix-a.md)
+- [Emoji-Beispiele (Smileys & Personen)](./examples/emoji-smileys-and-people.md)
+- [Emoji-Beispiele (Natur & Essen)](./examples/emoji-nature-and-food.md)
+- [Emoji-Beispiele (Aktivitäten & Reisen)](./examples/emoji-activities-and-travel.md)
+- [Emoji-Beispiele (Objekte, Symbole & Flaggen)](./examples/emoji-objects-symbols-flags.md)
+- [Appendix – Emoji- & Schriftabdeckung](./appendices/emoji-font-coverage.md)
 - [Zitationen & weiterführende Quellen](./references.md)
 
 ## Visuale Vorschau

--- a/gitbook_worker/defaults/fonts.yml
+++ b/gitbook_worker/defaults/fonts.yml
@@ -9,12 +9,12 @@ fonts:
     source_url: null
 
   EMOJI:
-    name: "Twemoji Mozilla"
+    name: "Twemoji Color Font"
     paths: []
-    download_url: "https://github.com/mozilla/twemoji-colr/releases/download/v0.7.0/Twemoji.Mozilla.ttf"
+    download_url: "https://github.com/13rac1/twemoji-color-font/releases/download/v15.1.0/TwemojiMozilla.ttf"
     license: "CC BY 4.0"
     license_url: "https://creativecommons.org/licenses/by/4.0/"
-    source_url: "https://github.com/mozilla/twemoji-colr"
+    source_url: "https://github.com/13rac1/twemoji-color-font"
 
   MONO:
     name: "DejaVu Sans Mono"


### PR DESCRIPTION
## Summary
- add four emoji example pages that cover the major categories used for layout and font testing and link them from the index
- document the required serif, CJK, and emoji fonts plus licensing details in a new appendix and align the emoji font configuration with the Twemoji Color Font source

## Testing
- pytest -q *(fails: the current container image does not ship the Twemoji font, causing smart_publisher tests to abort early with `SystemExit` and related runtime errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691defef32d0832a9479f4799adfe35d)