### PR TITLE
Rewrite PDF anchors for internal links

### DIFF
--- a/tests/test_preprocess_md.py
+++ b/tests/test_preprocess_md.py
@@ -16,6 +16,31 @@ def _wide_table(tmp_path, cols: int):
     return md
 
 
+def test_relative_markdown_links_point_to_pdf_anchor(tmp_path):
+    content_root = tmp_path / "content"
+    chapter = content_root / "chapters" / "chapter-01.md"
+    chapter.parent.mkdir(parents=True)
+    chapter.write_text("# Kapitel 1\n", encoding="utf-8")
+
+    index = content_root / "index.md"
+    index.parent.mkdir(parents=True, exist_ok=True)
+    index.write_text(
+        """
+[Kapitel 1](./chapters/chapter-01.md)
+[Detailabschnitt](./chapters/chapter-01.md#teil-1)
+![Symbol](./chapters/chapter-01.md)
+""".strip(),
+        encoding="utf-8",
+    )
+
+    out = preprocess_md.process(str(index), paper_format="a4")
+
+    assert "](#md-chapters-chapter-01)" in out
+    assert "](#teil-1)" in out
+    assert "![Symbol](./chapters/chapter-01.md)" in out
+    assert '<a id="md-index"></a>' in out
+
+
 def test_html_figure_block_converted(tmp_path):
     md = tmp_path / "figure.md"
     md.write_text(


### PR DESCRIPTION
## Summary
- rewrite relative .md links during preprocessing so that the combined PDF links jump to internal anchors instead of original Markdown files
- add deterministic anchor generation (skipping code fences) and inject anchors after YAML front matter to avoid breaking metadata
- cover the new behaviour with a regression test that exercises both file and section level links

## Testing
- `pytest tests/test_preprocess_md.py -q`
- `pytest tests/test_publisher.py::test_convert_folder_respects_existing_header_includes -q`
- `pytest --maxfail=1` *(fails: publisher integration tests require the Twemoji font in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df8c4a650832ab948f0ed3aa0122f)